### PR TITLE
Valkyrien Skies shipyard compat

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,12 +67,32 @@ minecraft {
 }
 
 repositories {
+  maven {
+    name = 'MinecraftForge'
+    url = 'https://maven.minecraftforge.net/'
+  }
 
+  maven {
+    name = 'Kotlin for Forge'
+    url = 'https://thedarkcolour.github.io/KotlinForForge/'
+  }
+
+  maven {
+    name = "Valkyrien Skies Internal"
+    url = 'https://maven.valkyrienskies.org'
+  }
 }
 
 dependencies {
   minecraft "net.minecraftforge:forge:${config.MINECRAFT_VERSION}-${config.FORGE_VERSION}"
   annotationProcessor 'org.spongepowered:mixin:0.8.5:processor'
+
+  compileOnly fg.deobf("org.valkyrienskies.core:api:${vs_core_version}")
+  compileOnly fg.deobf("org.valkyrienskies.core:impl:${vs_core_version}")
+  compileOnly fg.deobf("org.valkyrienskies.core:api-game:${vs_core_version}")
+  compileOnly fg.deobf("org.valkyrienskies.core:util:${vs_core_version}")
+  compileOnly fg.deobf("org.valkyrienskies:valkyrienskies-120-forge:${vs2_version}")
+  compileOnly 'thedarkcolour:kotlinforforge:4.10.0'
 }
 
 jar {

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,3 +2,6 @@
 # This is required to provide enough memory for the Minecraft decompilation process.
 org.gradle.jvmargs=-Xmx3G
 org.gradle.daemon=false
+
+vs2_version=2.3.0-beta.5+bcda04a482
+vs_core_version=1.1.0+b19b27c4a4

--- a/src/main/java/org/infernalstudios/oceanworlds/compat/ValkyrienSkiesCompat.java
+++ b/src/main/java/org/infernalstudios/oceanworlds/compat/ValkyrienSkiesCompat.java
@@ -1,0 +1,13 @@
+package org.infernalstudios.oceanworlds.compat;
+
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.chunk.ChunkAccess;
+import org.valkyrienskies.mod.common.VSGameUtilsKt;
+
+public class ValkyrienSkiesCompat {
+    // NOTE: This does NOT allow ships to work on this mod's false water
+    // Use the Block Swap mod to replace the false water with real water
+    public static boolean shouldFillChunkWithWater(ChunkAccess chunk, Level level) {
+        return !VSGameUtilsKt.isChunkInShipyard(level, chunk.getPos().x, chunk.getPos().z);
+    }
+}

--- a/src/main/java/org/infernalstudios/oceanworlds/mixin/ChunkStatusMixin.java
+++ b/src/main/java/org/infernalstudios/oceanworlds/mixin/ChunkStatusMixin.java
@@ -5,7 +5,9 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.function.Function;
 
+import net.minecraftforge.fml.ModList;
 import org.infernalstudios.oceanworlds.OceanWorlds;
+import org.infernalstudios.oceanworlds.compat.ValkyrienSkiesCompat;
 import org.infernalstudios.oceanworlds.config.FastNoiseSampler;
 import org.infernalstudios.oceanworlds.config.FastNoiseSampler.CellularSettings;
 import org.infernalstudios.oceanworlds.config.FastNoiseSampler.DomainWarpFractalSettings;
@@ -61,6 +63,12 @@ public class ChunkStatusMixin {
 					WorldGenRegion worldgenregion = new WorldGenRegion(level, chunks, chunkStatus, 1);
 					FastNoiseSampler noise = new FastNoiseSampler(GeneralSettings.get(), FractalSettings.get(),
 						CellularSettings.get(), DomainWarpSettings.get(), DomainWarpFractalSettings.get());
+
+					boolean fillChunk = true;
+					if (ModList.get().isLoaded("valkyrienskies")) {
+						fillChunk = ValkyrienSkiesCompat.shouldFillChunkWithWater(chunk, level);
+					}
+					if (!fillChunk) return;
 
 					for (int x = 0; x < 16; x++) {
 


### PR DESCRIPTION
This does NOT allow VS ships to float on false water. [Block Swap](https://www.curseforge.com/minecraft/mc-mods/block-swap) should be used on false water to replace it with Minecraft water, and you will probably want to remove the waves as well.
This PR only prevents water from spawning in shipyard chunks.